### PR TITLE
allow zero as metric value in toString method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -194,6 +194,10 @@
 		// Count the tags:
 		keys = Object.keys( tags );
 		numTags = keys.length;
+		
+		if ( numTags < 1 ) {
+			throw new Error( 'toString()::invalid datum. Datum must have at least one `tag`.' );
+		}
 
 		// Create a new array buffer:
 		buffer = new Array( 3+numTags );

--- a/lib/index.js
+++ b/lib/index.js
@@ -188,7 +188,7 @@
 		if ( !this._timestamp ) {
 			throw new Error( 'toString()::invalid datum. Datum must be assigned a `timestamp`.' );
 		}
-		if ( !this._value ) {
+		if ( !this._value && this._value !== 0 ) {
 			throw new Error( 'toString()::invalid datum. Datum must be assigned a `value`.' );
 		}
 		// Count the tags:

--- a/lib/index.js
+++ b/lib/index.js
@@ -185,7 +185,7 @@
 		if ( !this._metric ) {
 			throw new Error( 'toString()::invalid datum. Datum must be assigned a `metric` name.' );
 		}
-		if ( !this._timestamp ) {
+		if ( !this._timestamp && this._timestamp !== 0) {
 			throw new Error( 'toString()::invalid datum. Datum must be assigned a `timestamp`.' );
 		}
 		if ( !this._value && this._value !== 0 ) {

--- a/test/test.js
+++ b/test/test.js
@@ -289,13 +289,16 @@ describe( 'lib', function tests() {
 		it( 'should throw an error if a datum is not assigned a metric name', function test() {
 			var datum = createDatum(),
 				timestamp = Date.now(),
-				value = Math.random();
+				value = Math.random(),
+				tagk = 'tagk',
+				tagv = 'tagv';
 
 			datum
 				.timestamp( timestamp )
-				.value( value );
+				.value( value )
+				.tags( tagk, tagv );
 
-			expect( foo ).to.throw( Error );
+			expect( foo ).to.throw( Error, 'name' );
 
 			function foo() {
 				datum.toString();
@@ -305,13 +308,16 @@ describe( 'lib', function tests() {
 		it( 'should throw an error if a datum is not assigned a timestamp', function test() {
 			var datum = createDatum(),
 				metric = 'cpu.utilization',
-				value = Math.random();
+				value = Math.random(),
+				tagk = 'tagk',
+				tagv = 'tagv';
 
 			datum
 				.metric( metric )
-				.value( value );
+				.value( value )
+				.tags( tagk, tagv );
 
-			expect( foo ).to.throw( Error );
+				expect( foo ).to.throw( Error, 'timestamp' );
 
 			function foo() {
 				datum.toString();
@@ -321,13 +327,16 @@ describe( 'lib', function tests() {
 		it( 'should throw an error if a datum is not assigned a value', function test() {
 			var datum = createDatum(),
 				metric = 'cpu.utilization',
-				timestamp = Date.now();
+				timestamp = Date.now(),
+				tagk = 'tagk',
+				tagv = 'tagv';
 
 			datum
 				.metric( metric )
-				.timestamp( timestamp );
+				.timestamp( timestamp )
+				.tags( tagk, tagv );
 
-			expect( foo ).to.throw( Error );
+			expect( foo ).to.throw( Error, 'value' );
 
 			function foo() {
 				datum.toString();
@@ -338,17 +347,38 @@ describe( 'lib', function tests() {
 			var datum = createDatum(),
 				metric = 'cpu.utilization',
 				timestamp = Date.now(),
+				tagk = 'tagk',
+				tagv = 'tagv',
 				value = 0,
 				expected;
 
-			expected = metric + ' ' + timestamp + ' ' + value;
+			expected = metric + ' ' + timestamp + ' ' + value + ' ' + tagk + '=' + tagv;
 
 			datum
 				.metric( metric )
 				.timestamp( timestamp )
+				.tags( tagk, tagv )
 				.value( value );
 
 			assert.strictEqual( datum.toString(), expected );
+		});
+		
+		it( 'should throw an error if a datum is not assigned at least one tag', function test() {
+			var datum = createDatum(),
+				metric = 'cpu.utilization',
+				value = Math.random(),
+				timestamp = Date.now();
+
+			datum
+				.metric( metric )
+				.value( value )
+				.timestamp( timestamp );
+
+			expect( foo ).to.throw( Error, 'tag' );
+
+			function foo() {
+				datum.toString();
+			}
 		});
 
 		it( 'should serialize a datum', function test() {

--- a/test/test.js
+++ b/test/test.js
@@ -333,6 +333,23 @@ describe( 'lib', function tests() {
 				datum.toString();
 			}
 		});
+		
+		it( 'should accept a value of 0', function test() {
+			var datum = createDatum(),
+				metric = 'cpu.utilization',
+				timestamp = Date.now(),
+				value = 0,
+				expected;
+
+			expected = metric + ' ' + timestamp + ' ' + value;
+
+			datum
+				.metric( metric )
+				.timestamp( timestamp )
+				.value( value );
+
+			assert.strictEqual( datum.toString(), expected );
+		});
 
 		it( 'should serialize a datum', function test() {
 			var datum = createDatum(),


### PR DESCRIPTION
Currently one cannot write a metric value of `0` using the datum `toString` method. An error is thrown with message:
`toString()::invalid datum. Datum must be assigned a 'value'.`

This PR allows a metric value of `zero` while still throwing an error given any other falsy value.
